### PR TITLE
works for 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.* | 5.1.*"
+        "illuminate/support": "5.0.* | 5.1.* | 5.2.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Witty/LaravelDbBackup/Commands/BackupCommand.php
+++ b/src/Witty/LaravelDbBackup/Commands/BackupCommand.php
@@ -125,7 +125,7 @@ class BackupCommand extends BaseCommand
 	protected function uploadS3()
 	{
 		$bucket = $this->option('upload-s3');
-		$s3 = AWS::get('s3');
+		$s3 = AWS::createClient('s3');
 		$s3->putObject([
 			'Bucket'     => $bucket,
 			'Key'        => $this->getS3DumpsPath() . '/' . $this->fileName,


### PR DESCRIPTION
Now works with Laravel 5.2 + it works with Amazon AWS S3.

Edited `get` to `createClient` thanks to https://github.com/larkinwhitaker/laravel-db-backup/issues/1
