### PR TITLE
Adding multi line export on dump procedure for MySQL and PostgreSQL

### DIFF
--- a/src/Witty/LaravelDbBackup/Commands/BackupCommand.php
+++ b/src/Witty/LaravelDbBackup/Commands/BackupCommand.php
@@ -34,7 +34,9 @@ class BackupCommand extends BaseCommand
 		$this->filePath = $dbfile->path();
 		$this->fileName = $dbfile->name();
 
-		$status = $database->dump($this->filePath);
+		$status = $database->dump($this->filePath, [
+			'extended-insert' => !is_null($this->input->getOption('extended-insert'))
+		]);
 		$handler = new BackupHandler( $this->colors );
 
 		// Error
@@ -102,7 +104,8 @@ class BackupCommand extends BaseCommand
 		return [
 			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to backup'],
 			['upload-s3', 'u', InputOption::VALUE_REQUIRED, 'Upload the dump to your S3 bucket'],
-			['keep-only-s3', true, InputOption::VALUE_NONE, 'Delete the local dump after upload to S3 bucket']
+			['keep-only-s3', true, InputOption::VALUE_NONE, 'Delete the local dump after upload to S3 bucket'],
+			['extended-insert', null, InputOption::VALUE_OPTIONAL, 'Dump data as INSERT command with explicit column names (slow but optimal for database VCS)']
 		];
 	}
 

--- a/src/Witty/LaravelDbBackup/Commands/BackupCommand.php
+++ b/src/Witty/LaravelDbBackup/Commands/BackupCommand.php
@@ -35,7 +35,8 @@ class BackupCommand extends BaseCommand
 		$this->fileName = $dbfile->name();
 
 		$status = $database->dump($this->filePath, [
-			'extended-insert' => !is_null($this->input->getOption('extended-insert'))
+			'extended-insert' => !is_null($this->input->getOption('extended-insert')),
+			'single-transaction' => !is_null($this->input->getOption('single-transaction')),
 		]);
 		$handler = new BackupHandler( $this->colors );
 
@@ -105,7 +106,8 @@ class BackupCommand extends BaseCommand
 			['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to backup'],
 			['upload-s3', 'u', InputOption::VALUE_REQUIRED, 'Upload the dump to your S3 bucket'],
 			['keep-only-s3', true, InputOption::VALUE_NONE, 'Delete the local dump after upload to S3 bucket'],
-			['extended-insert', null, InputOption::VALUE_OPTIONAL, 'Dump data as INSERT command with explicit column names (slow but optimal for database VCS)']
+			['extended-insert', null, InputOption::VALUE_OPTIONAL, 'Dump data as INSERT command with explicit column names (slow but optimal for database VCS)'],
+			['single-transaction', null, InputOption::VALUE_OPTIONAL, 'Issue a BEGIN SQL statement before dumping data from server (only on MySQL)']
 		];
 	}
 

--- a/src/Witty/LaravelDbBackup/Databases/DatabaseContract.php
+++ b/src/Witty/LaravelDbBackup/Databases/DatabaseContract.php
@@ -9,7 +9,7 @@ interface DatabaseContract
 	 * 
 	 * @return boolean
 	 */
-	public function dump($destinationFile, $dumpOptions);
+	public function dump($destinationFile, array $dumpOptions=[]);
 
 	/**
 	 * Restore a database dump

--- a/src/Witty/LaravelDbBackup/Databases/DatabaseContract.php
+++ b/src/Witty/LaravelDbBackup/Databases/DatabaseContract.php
@@ -9,7 +9,7 @@ interface DatabaseContract
 	 * 
 	 * @return boolean
 	 */
-	public function dump($destinationFile);
+	public function dump($destinationFile, $dumpOptions);
 
 	/**
 	 * Restore a database dump

--- a/src/Witty/LaravelDbBackup/Databases/MySQLDatabase.php
+++ b/src/Witty/LaravelDbBackup/Databases/MySQLDatabase.php
@@ -45,15 +45,17 @@ class MySQLDatabase implements DatabaseContract
 	 * Create a database dump
 	 * 
 	 * @param string $destinationFile
+	 * @param array $dumpOptions
 	 * @return boolean
 	 */
-	public function dump($destinationFile)
+	public function dump($destinationFile, array $dumpOptions=[])
 	{
-		$command = sprintf('%smysqldump --user=%s --password=%s --host=%s --port=%s %s > %s',
+		$command = sprintf('%smysqldump --user=%s --password=%s --host=%s %s --port=%s %s > %s',
 			$this->getDumpCommandPath(),
 			escapeshellarg($this->user),
 			escapeshellarg($this->password),
 			escapeshellarg($this->host),
+			array_key_exists('extended-insert', $dumpOptions) && filter_var($dumpOptions['extended-insert'], FILTER_VALIDATE_BOOLEAN) ? '--skip-extended-insert' : '',
 			escapeshellarg($this->port),
 			escapeshellarg($this->database),
 			escapeshellarg($destinationFile)

--- a/src/Witty/LaravelDbBackup/Databases/MySQLDatabase.php
+++ b/src/Witty/LaravelDbBackup/Databases/MySQLDatabase.php
@@ -50,12 +50,13 @@ class MySQLDatabase implements DatabaseContract
 	 */
 	public function dump($destinationFile, array $dumpOptions=[])
 	{
-		$command = sprintf('%smysqldump --user=%s --password=%s --host=%s %s --port=%s %s > %s',
+		$command = sprintf('%smysqldump --user=%s --password=%s --host=%s %s %s --port=%s %s > %s',
 			$this->getDumpCommandPath(),
 			escapeshellarg($this->user),
 			escapeshellarg($this->password),
 			escapeshellarg($this->host),
 			array_key_exists('extended-insert', $dumpOptions) && filter_var($dumpOptions['extended-insert'], FILTER_VALIDATE_BOOLEAN) ? '--skip-extended-insert' : '',
+			array_key_exists('single-transaction', $dumpOptions) && filter_var($dumpOptions['single-transaction'], FILTER_VALIDATE_BOOLEAN) ? '--single-transaction' : '',
 			escapeshellarg($this->port),
 			escapeshellarg($this->database),
 			escapeshellarg($destinationFile)

--- a/src/Witty/LaravelDbBackup/Databases/PostgresDatabase.php
+++ b/src/Witty/LaravelDbBackup/Databases/PostgresDatabase.php
@@ -41,12 +41,14 @@ class PostgresDatabase implements DatabaseContract
 	 * Create a database dump
 	 * 
 	 * @param string $destinationFile
+	 * @param array $dumpOptions
 	 * @return boolean
 	 */
-	public function dump($destinationFile)
+	public function dump($destinationFile, array $dumpOptions=[])
 	{
-		$command = sprintf('PGPASSWORD=%s pg_dump -Fc --no-acl --no-owner -h %s -U %s %s > %s',
+		$command = sprintf('PGPASSWORD=%s pg_dump -Fc --no-acl --no-owner %s -h %s -U %s %s > %s',
 			escapeshellarg($this->password),
+			array_key_exists('extended-insert', $dumpOptions) && filter_var($dumpOptions['extended-insert'], FILTER_VALIDATE_BOOLEAN) ? '--column-inserts' : '',
 			escapeshellarg($this->host),
 			escapeshellarg($this->user),
 			escapeshellarg($this->database),

--- a/src/Witty/LaravelDbBackup/Databases/SqliteDatabase.php
+++ b/src/Witty/LaravelDbBackup/Databases/SqliteDatabase.php
@@ -32,9 +32,10 @@ class SqliteDatabase implements DatabaseContract
 	 * Create a database dump
 	 * 
 	 * @param string $destinationFile
+	 * @param array $dumpOptions
 	 * @return boolean
 	 */
-	public function dump($destinationFile)
+	public function dump($destinationFile, array $dumpOptions=[])
 	{
 		$command = sprintf('cp %s %s',
 			escapeshellarg($this->databaseFile),


### PR DESCRIPTION
Hello, I implemented a raw improvement to handle some options on dump phase (only on MySql and PostgreSql: I'm not familiar with sqlite).
Passing an associative array to contractor is possible to append options such as extended-insert: it allows to avoid chunk of insert on dump, useful in case of database backup for multi-tenant database applications (such as software-as-a-services). I know file is bigger and not transactional but it ease the versioning.
Hope it could be useful to others, maybe with other contributions! :)

Apologies if I did some mistakes: it's my second time I'm contributing to a GitHub repo.
